### PR TITLE
Added "center" as possible parameter for version number header.

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -19,7 +19,7 @@ Check the [Github](https://github.com/damienaicheh/azure-devops-launch-icon-badg
     bannerVersionNameText: 'Prerelease'  # Optional. Default is: ''
     bannerVersionNameColor: '#C5000D' # Optional. Default is: '#C5000D'
     bannerVersionNameTextColor: '#FFFFFF' # Optional. Default is: '#FFFFFF'
-    bannerVersionNumberPosition: 'top' # Optional. top, bottom, none. Default is: 'none'
+    bannerVersionNumberPosition: 'top' # Optional. top, bottom, center, none. Default is: 'none'
     bannerVersionNumberText: '1.2.3' # Optional. Default is: ''
     bannerVersionNumberColor: '#34424F' # Optional. Default is: '#34424F'
     bannerVersionNumberTextColor: '#FFFFFF' # Optional. Default is: '#FFFFFF'

--- a/launchIconBadgeTask/launch-icon-badge.ts
+++ b/launchIconBadgeTask/launch-icon-badge.ts
@@ -78,10 +78,8 @@ async function generate(imagePath: string, headerBannerPosition: string, headerP
         let x = img.height;
         let y = img.width;
 
-        if (headerPosition == 'top') {
-            drawVersionheader(ctx, x, y, true, iconHeaderOptions);
-        } else if (headerPosition == 'bottom') {
-            drawVersionheader(ctx, x, y, false, iconHeaderOptions);
+        if (headerPosition != 'none') {
+            drawVersionheader(ctx, x, y, headerPosition, iconHeaderOptions);
         }
 
         switch (headerBannerPosition) {
@@ -113,7 +111,7 @@ async function generate(imagePath: string, headerBannerPosition: string, headerP
 }
 
 /// Draw version number banner on top or bottom of the icon.
-function drawVersionheader(ctx: CanvasRenderingContext2D, x: number, y: number, onTop: boolean, iconHeaderOptions: IconOptions) {
+function drawVersionheader(ctx: CanvasRenderingContext2D, x: number, y: number, headerPosition: string, iconHeaderOptions: IconOptions) {
     ctx.save();
 
     let height = 0.15 * y;
@@ -121,11 +119,14 @@ function drawVersionheader(ctx: CanvasRenderingContext2D, x: number, y: number, 
 
     ctx.fillStyle = iconHeaderOptions.color;
 
-    if (onTop) {
+    if (headerPosition == 'top') {
         ctx.fillRect(0.25 * x, 0, width, height);
-    } else {
+    } else if (headerPosition == 'bottom') {
         ctx.fillRect(0.25 * x, y - height, width, height);
+    } else if (headerPosition == 'center') {
+        ctx.fillRect(0.25 * x, (y / 2) - height, width, height);
     }
+
 
     ctx.fillStyle = iconHeaderOptions.textColor;
 
@@ -135,10 +136,12 @@ function drawVersionheader(ctx: CanvasRenderingContext2D, x: number, y: number, 
     let textCenterX = (x / 2) - (measure.width / 2);
     var textCenterY = 0;
 
-    if (onTop) {
+    if (headerPosition == 'top') {
         textCenterY = height - (((height) - measure.emHeightAscent - measure.emHeightDescent) / 2);
-    } else {
+    } else if (headerPosition == 'bottom') {
         textCenterY = y - (((height) - measure.emHeightAscent - measure.emHeightDescent) / 2);
+    } else if (headerPosition == 'center') {
+        textCenterY = (y / 2) - (((height) - measure.emHeightAscent - measure.emHeightDescent) / 2);
     }
 
     ctx.translate(textCenterX, textCenterY);

--- a/launchIconBadgeTask/task.json
+++ b/launchIconBadgeTask/task.json
@@ -82,7 +82,8 @@
             "options": {
                 "none": "None",
                 "top": "Top",
-                "bottom": "Bottom"
+                "bottom": "Bottom",
+                "center": "Center"
             }
         },
         {

--- a/samples/azure-pipelines.yml
+++ b/samples/azure-pipelines.yml
@@ -29,7 +29,7 @@ steps:
     contents: '**/*.png'
     bannerVersionNamePosition: 'topRight'
     bannerVersionNameText: 'Debug'
-    bannerVersionNumberPosition: 'bottom'
+    bannerVersionNumberPosition: 'center'
     bannerVersionNumberText: '12.34.567'
 
 - task: ExtractVersionFromTag@1


### PR DESCRIPTION
Based on https://github.com/damienaicheh/azure-devops-launch-icon-badge/issues/6 Android OS cropping out the version number.  This would allow users the option to output the version number in the center, if desired.  